### PR TITLE
Handle graceful shutdown for server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -24,8 +24,25 @@ if (!process.env.DATABASE_URL) {
   console.warn('DATABASE_URL environment variable is not set. Database operations will fail.');
 }
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Authentication API running on port ${PORT}`);
+});
+
+const gracefulShutdown = (signal) => {
+  console.log(`${signal} received. Closing server gracefully.`);
+  server.close(() => {
+    console.log('Server closed. Exiting process.');
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    console.error('Graceful shutdown timed out. Forcing exit.');
+    process.exit(1);
+  }, 10000).unref();
+};
+
+['SIGTERM', 'SIGINT'].forEach((signal) => {
+  process.on(signal, () => gracefulShutdown(signal));
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- add graceful shutdown handling for SIGTERM/SIGINT so the server exits cleanly when npm sends termination signals
- log shutdown progress and enforce a timeout before forcing exit

## Testing
- npm start (and interrupted with Ctrl+C)


------
https://chatgpt.com/codex/tasks/task_e_68cc8d7a0e88832aa4f539ffbc242e2e