### PR TITLE
Remove event REST endpoints and rely on Hasura for events

### DIFF
--- a/metadata/metadata.yaml
+++ b/metadata/metadata.yaml
@@ -96,4 +96,148 @@ sources:
           - name: user
             using:
               foreign_key_constraint_on: user_id
+      - table:
+          schema: public
+          name: event_categories
+        array_relationships:
+          - name: events
+            using:
+              foreign_key_constraint_on:
+                column: category_id
+                table:
+                  schema: public
+                  name: events
+        select_permissions:
+          - role: user
+            permission:
+              columns:
+                - id
+                - name
+                - slug
+                - created_at
+                - updated_at
+              filter: {}
+              allow_aggregations: false
+              limit: null
+      - table:
+          schema: public
+          name: events
+        object_relationships:
+          - name: category
+            using:
+              foreign_key_constraint_on: category_id
+          - name: owner
+            using:
+              foreign_key_constraint_on: owner_id
+        array_relationships:
+          - name: tags
+            using:
+              foreign_key_constraint_on:
+                column: event_id
+                table:
+                  schema: public
+                  name: event_tags
+          - name: highlights
+            using:
+              foreign_key_constraint_on:
+                column: event_id
+                table:
+                  schema: public
+                  name: event_highlights
+        select_permissions:
+          - role: user
+            permission:
+              columns:
+                - id
+                - slug
+                - title
+                - description
+                - category_id
+                - owner_id
+                - cover_url
+                - start_at
+                - end_at
+                - timezone
+                - venue_name
+                - street
+                - city
+                - state
+                - country
+                - latitude
+                - longitude
+                - base_price_cents
+                - currency
+                - policy
+                - resolution
+                - status
+                - visibility
+                - max_participants
+                - created_at
+                - updated_at
+                - published_at
+              filter:
+                _or:
+                  - visibility:
+                      _in:
+                        - public
+                        - unlisted
+                  - owner_id:
+                      _eq: X-Hasura-User-Id
+              allow_aggregations: false
+              limit: null
+      - table:
+          schema: public
+          name: event_tags
+        object_relationships:
+          - name: event
+            using:
+              foreign_key_constraint_on: event_id
+        select_permissions:
+          - role: user
+            permission:
+              columns:
+                - id
+                - event_id
+                - tag
+                - created_at
+              filter:
+                event:
+                  _or:
+                    - visibility:
+                        _in:
+                          - public
+                          - unlisted
+                    - owner_id:
+                        _eq: X-Hasura-User-Id
+              allow_aggregations: false
+              limit: null
+      - table:
+          schema: public
+          name: event_highlights
+        object_relationships:
+          - name: event
+            using:
+              foreign_key_constraint_on: event_id
+        select_permissions:
+          - role: user
+            permission:
+              columns:
+                - id
+                - event_id
+                - type
+                - asset_url
+                - caption
+                - sort_order
+                - created_at
+              filter:
+                event:
+                  _or:
+                    - visibility:
+                        _in:
+                          - public
+                          - unlisted
+                    - owner_id:
+                        _eq: X-Hasura-User-Id
+              allow_aggregations: false
+              limit: null
 

--- a/migrations/0002_create_event_schema.sql
+++ b/migrations/0002_create_event_schema.sql
@@ -1,0 +1,102 @@
+DO $$
+BEGIN
+  CREATE TYPE public.event_status AS ENUM ('draft', 'scheduled', 'active', 'archived', 'completed');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.event_visibility AS ENUM ('public', 'unlisted', 'private');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.event_highlight_type AS ENUM ('banner', 'reel', 'story');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS public.event_categories (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+DROP TRIGGER IF EXISTS set_updated_at_event_categories ON public.event_categories;
+CREATE TRIGGER set_updated_at_event_categories
+BEFORE UPDATE ON public.event_categories
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE IF NOT EXISTS public.events (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  description TEXT,
+  category_id UUID NOT NULL REFERENCES public.event_categories(id) ON DELETE RESTRICT,
+  owner_id UUID NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  cover_url TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ,
+  timezone TEXT NOT NULL,
+  venue_name TEXT,
+  street TEXT,
+  city TEXT,
+  state TEXT,
+  country TEXT,
+  latitude NUMERIC(9, 6),
+  longitude NUMERIC(9, 6),
+  base_price_cents INTEGER,
+  currency CHAR(3),
+  policy TEXT,
+  resolution TEXT,
+  status public.event_status NOT NULL DEFAULT 'draft',
+  visibility public.event_visibility NOT NULL DEFAULT 'private',
+  max_participants INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  published_at TIMESTAMPTZ
+);
+
+DROP TRIGGER IF EXISTS set_updated_at_events ON public.events;
+CREATE TRIGGER set_updated_at_events
+BEFORE UPDATE ON public.events
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX IF NOT EXISTS idx_events_category_id ON public.events(category_id);
+CREATE INDEX IF NOT EXISTS idx_events_owner_id ON public.events(owner_id);
+CREATE INDEX IF NOT EXISTS idx_events_start_at ON public.events(start_at);
+CREATE INDEX IF NOT EXISTS idx_events_status ON public.events(status);
+CREATE INDEX IF NOT EXISTS idx_events_visibility ON public.events(visibility);
+
+CREATE TABLE IF NOT EXISTS public.event_tags (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  tag TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (event_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_tags_event_id ON public.event_tags(event_id);
+
+CREATE TABLE IF NOT EXISTS public.event_highlights (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  type public.event_highlight_type NOT NULL,
+  asset_url TEXT NOT NULL,
+  caption TEXT,
+  sort_order INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_highlights_event_id ON public.event_highlights(event_id);
+CREATE INDEX IF NOT EXISTS idx_event_highlights_sort_order ON public.event_highlights(event_id, sort_order);

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,10 @@ docker run --rm -p 3000:3000 \
 npm run migrate:status
 ```
 
-A primeira migração (`0001_create_auth_schema.sql`) cria as tabelas `users`, `roles`, `user_roles`, `refresh_tokens`, bem como uma função de atualização de `updated_at` e papéis padrão (`user` e `admin`).
+As migrações incluem:
+
+- `0001_create_auth_schema.sql`: cria as tabelas `users`, `roles`, `user_roles`, `refresh_tokens`, bem como a função `set_updated_at` e papéis padrão (`user` e `admin`).
+- `0002_create_event_schema.sql`: adiciona `event_categories`, `events`, `event_tags` e `event_highlights`, além de enums e índices auxiliares. A API não implementa endpoints para este domínio; a manipulação deve ser feita diretamente pelo Hasura utilizando essas tabelas.
 
 ## Endpoints Disponíveis
 


### PR DESCRIPTION
## Summary
- remove the event controller, service, routes and optional auth middleware so the API only exposes auth functionality
- keep the existing event migration for table creation while clarifying in the README that Hasura should manage the domain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03740851c832a9f8c1a18e2eee116