### PR TITLE
Add optional photographer profile fields

### DIFF
--- a/metadata/metadata.yaml
+++ b/metadata/metadata.yaml
@@ -66,6 +66,14 @@ sources:
             permission:
               columns:
                 - user_id
+                - biography
+                - phone_number
+                - website_url
+                - social_links
+                - profile_image_url
+                - cover_image_url
+                - cpf
+                - accepted_terms
                 - created_at
               filter:
                 user_id:

--- a/migrations/0003_add_photographer_profile_fields.sql
+++ b/migrations/0003_add_photographer_profile_fields.sql
@@ -1,0 +1,9 @@
+ALTER TABLE public.photographers
+  ADD COLUMN biography TEXT,
+  ADD COLUMN phone_number TEXT,
+  ADD COLUMN website_url TEXT,
+  ADD COLUMN social_links TEXT,
+  ADD COLUMN profile_image_url TEXT,
+  ADD COLUMN cover_image_url TEXT,
+  ADD COLUMN cpf TEXT,
+  ADD COLUMN accepted_terms BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -13,7 +13,25 @@ const buildRequestMetadata = (req) => ({
 
 export const register = async (req, res, next) => {
   try {
-    const { email, password, displayName, role } = req.body;
+    const {
+      email,
+      password,
+      displayName,
+      role,
+      biography,
+      phoneNumber,
+      phone,
+      websiteUrl,
+      website,
+      socialLinks,
+      profileImageUrl,
+      profilePhotoUrl,
+      coverImageUrl,
+      coverPhotoUrl,
+      cpf,
+      acceptedTerms,
+      photographerProfile: nestedPhotographerProfile
+    } = req.body;
 
     if (!email || !password || !displayName) {
       const error = new Error('email, password and displayName are required');
@@ -21,7 +39,31 @@ export const register = async (req, res, next) => {
       throw error;
     }
 
-    const result = await registerUser({ email, password, displayName, role }, buildRequestMetadata(req));
+    const photographerProfile = {
+      ...(nestedPhotographerProfile || {})
+    };
+
+    const additionalProfileFields = {
+      biography,
+      phoneNumber: phoneNumber ?? phone,
+      websiteUrl: websiteUrl ?? website,
+      socialLinks,
+      profileImageUrl: profileImageUrl ?? profilePhotoUrl,
+      coverImageUrl: coverImageUrl ?? coverPhotoUrl,
+      cpf,
+      acceptedTerms
+    };
+
+    Object.entries(additionalProfileFields).forEach(([key, value]) => {
+      if (value !== undefined) {
+        photographerProfile[key] = value;
+      }
+    });
+
+    const result = await registerUser(
+      { email, password, displayName, role, photographerProfile },
+      buildRequestMetadata(req)
+    );
     res.status(201).json(result);
   } catch (error) {
     next(error);


### PR DESCRIPTION
## Summary
- add optional profile columns to the `photographers` table and expose them through Hasura metadata
- persist extended photographer data during registration and return it in auth responses
- hydrate login, refresh, and profile endpoints with the stored photographer profile when applicable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d04dc0e8c8832aa3bc2bf0fe62fda8