### PR TITLE
Allow all origins via basic CORS middleware

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,18 @@ const app = express();
 
 const isProduction = process.env.NODE_ENV === 'production';
 
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS');
+  res.header('Access-Control-Allow-Headers', req.header('Access-Control-Request-Headers') || 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+
+  next();
+});
+
 app.use(express.json());
 
 app.get('/health', (_req, res) => {


### PR DESCRIPTION
## Summary
- add a simple CORS middleware to respond to requests from any origin
- handle OPTIONS preflight requests with a 204 response

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d153ffa8d0832a928cbb3e284c613a