### PR TITLE
Add root health endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,13 @@ app.use((req, res, next) => {
 
 app.use(express.json());
 
+app.get('/', (_req, res) => {
+  res.json({
+    name: 'olha-foto-backend',
+    status: 'ok'
+  });
+});
+
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });


### PR DESCRIPTION
## Summary
- add a root endpoint that returns a simple JSON payload so upstream health checks succeed
- keep the existing /health endpoint for compatibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2aa8543fc832aa9da44c44c77f6ba