### PR TITLE
Add migration for default admin user

### DIFF
--- a/migrations/0005_insert_default_admin.sql
+++ b/migrations/0005_insert_default_admin.sql
@@ -1,0 +1,35 @@
+DO $$
+DECLARE
+  admin_id UUID;
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.users WHERE email = 'marlon@admin.com'
+  ) THEN
+    RAISE NOTICE 'Default admin user already exists. Skipping insertion.';
+  ELSE
+    admin_id := uuid_generate_v4();
+
+    INSERT INTO public.users (
+      id,
+      email,
+      password_hash,
+      display_name,
+      role,
+      is_active,
+      accepted_terms
+    )
+    VALUES (
+      admin_id,
+      'marlon@admin.com',
+      '$2b$10$Cmsf8I8SMldOJHGdpQqSa.Vuoq3t0B5lHbStJABadDCd8/uFj/hiG',
+      'Marlon',
+      'admin',
+      TRUE,
+      TRUE
+    );
+
+    INSERT INTO public.admins (user_id)
+    VALUES (admin_id);
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add a migration that seeds a default admin user named Marlon
- ensure the admin record is only created when it does not already exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0fa7ba00832aaf456b51b3f3a37c